### PR TITLE
Support DATABASE_URL

### DIFF
--- a/lib/arpry/class_factory.rb
+++ b/lib/arpry/class_factory.rb
@@ -33,7 +33,7 @@ module Arpry
       Class.new(ActiveRecord::Base).tap do |klass|
         klass.logger = Arpry::Logger.logger
         self.class.const_set(class_name, klass)
-        klass.establish_connection(conn_option)
+        klass.establish_connection(conn_option.presence)
       end
     end
 

--- a/lib/arpry/cli.rb
+++ b/lib/arpry/cli.rb
@@ -27,8 +27,8 @@ module Arpry
       @params = {}
       args = opt.parse(@argv, into: @params)
 
-      @params[:database] ||= args[0]
-      if File.exist?(@params[:database])
+      @params[:database] ||= args[0] if args.present?
+      if @params[:database] && File.exist?(@params[:database])
         @params[:adapter] ||= 'sqlite3'
       end
     end


### PR DESCRIPTION
AR::Base.establish_connection uses `DATABASE_URL` if the arguments is empty.

#8 